### PR TITLE
fix: Phase 8 iteration-1 gaps

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -12,7 +12,7 @@ rust_library(
     crate_root = "src/lib.rs",
     edition = "2021",
     rustc_env = {"SQLX_OFFLINE": "true"},
-    compile_data = glob([".sqlx/**/*.json", "migrations/*.sql"]) + ["//frontend:dist"],
+    compile_data = glob([".sqlx/**/*.json", "migrations/*.sql"], allow_empty = True) + ["//frontend:dist"],
     deps = [
         "@crates//:axum",
         "@crates//:mime_guess",
@@ -40,7 +40,7 @@ rust_library(
     crate_root = "src/lib.rs",
     edition = "2021",
     rustc_env = {"SQLX_OFFLINE": "true"},
-    compile_data = glob([".sqlx/**/*.json", "migrations/*.sql"]) + ["//frontend:dist"],
+    compile_data = glob([".sqlx/**/*.json", "migrations/*.sql"], allow_empty = True) + ["//frontend:dist"],
     deps = [
         "@crates//:axum",
         "@crates//:mime_guess",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 Project conventions and guardrails for AI coding agents working in this repo.
 Read this before writing code or running commands.
 
-Last verified: 2026-04-22
+Last verified: 2026-04-22 (Phase 8 iteration-1 fixes: 2026-04-23)
 
 ## Status
 
@@ -68,6 +68,9 @@ They present a state that does not match the real build and confuse both humans 
 - **Newtype-wrap primitives that carry domain meaning:** `NoteId(Uuid)` today. As new semantically-distinct values appear (other IDs, timestamps with semantic meaning, etc.), wrap them. Never pass raw `String` or `u64` across an API boundary when the value has a name.
 - **Sealed `enum`s for exhaustive domain modelling;** lean on the exhaustiveness checker. `thiserror` for error types in library/adapter code.
 - **Cargo.toml is the source of truth** for third-party crates. Bazel reads it via `crate_universe` in `from_cargo` mode — never hand-write `BUILD` files for external crates. After editing Cargo.toml, repin with `just bazel-repin`. Both `Cargo.lock` and `MODULE.bazel.lock` are committed.
+- **Adding a new crate is a two-step Bazel update:**
+  1. Add the crate to `Cargo.toml`, then run `just bazel-repin` to regenerate `MODULE.bazel.lock` so the crate is fetchable.
+  2. Add `"@crates//:<crate-name>"` to the `deps = [...]` list of every Bazel target that uses it (typically `:lib`, `:lib_with_test_helpers`, `:app`, and any test target). `crate_universe` makes the crate *available* but does not auto-wire it into target dep lists. Forgetting step 2 produces `unresolved import` errors at `bazel build` time even though `cargo check` succeeds.
 
 ## TypeScript Conventions
 
@@ -109,6 +112,7 @@ Anything with a non-trivial input space — parsers, state machines, serializers
 
 - Tag with `#[ignore]` and Bazel `manual` tag.
 - Run via `just test-integration` or `bazel test //tests:integration_db --config=live` against docker-compose PostgreSQL.
+- **Required env:** `DATABASE_URL` must be exported in your shell before invoking `just test-integration`. The Justfile forwards it into the Bazel sandbox via `--test_env=DATABASE_URL`; without it set, the test silently skips (it cannot reach the DB from inside the sandbox).
 - Use real DB engines, not in-memory substitutes.
 
 ### Mutation Testing (CI, nightly)

--- a/Justfile
+++ b/Justfile
@@ -10,18 +10,23 @@ dev:
 reset-cluster:
     kind delete cluster --name rust-app-template || true
 
+# Build the frontend bundle. Required before any Bazel target that consumes //frontend:dist.
+fe-build:
+    cd frontend && pnpm install --frozen-lockfile && pnpm build
+
 # Offline test suite (fakes; no Postgres required).
 # Note: test targets //tests:api and //tests:properties come online in Phase 2/3.
 # Until then, this recipe will fail with a bazel error (expected state for Phase 1).
-test:
+test: fe-build
     bazel test //tests:api //tests:properties --test_output=errors
 
-# Integration tests that require `just dev` to be running (real kind-hosted Postgres).
-test-integration:
-    bazel test //tests:integration_db --test_output=errors --cache_test_results=no --test_arg=--ignored --test_arg=--test-threads=1
+# Integration tests that require live Postgres reachable via DATABASE_URL.
+# DATABASE_URL is forwarded into the Bazel sandbox via --test_env.
+test-integration: fe-build
+    bazel test //tests:integration_db --test_output=errors --cache_test_results=no --test_arg=--ignored --test_arg=--test-threads=1 --test_env=DATABASE_URL
 
 # Formatting, linting, and `just test` — matches CI.
-check:
+check: fe-build
     cargo fmt --check
     cargo clippy --all-targets -- -D warnings
     just test


### PR DESCRIPTION
## Summary

Phase 8 Pass-2 (rebuilding `static-embedder-v2` on top of the template) surfaced four template gaps in the first rebuild iteration. This PR fixes all four.

## Gaps fixed

1. **Fresh-clone `just test` fails on empty `frontend/dist/`.** New `fe-build` Justfile recipe runs `pnpm install --frozen-lockfile && pnpm build`; `test`, `test-integration`, and `check` now depend on it. `just dev` is no longer the only entrypoint that primes the frontend bundle.
2. **`BUILD.bazel` glob fails when migrations directory is empty.** Added `allow_empty = True` to the `migrations/*.sql` glob on both `:lib` and `:lib_with_test_helpers`. A consumer with no migrations is now valid.
3. **Adding a Cargo crate requires a manual `BUILD.bazel` deps update.** `crate_universe` makes the crate fetchable but doesn't auto-wire it into target dep lists. CLAUDE.md now documents the two-step process explicitly.
4. **`just test-integration` silently skips because Bazel sandbox doesn't see `DATABASE_URL`.** Added `--test_env=DATABASE_URL` to the recipe; documented the requirement in CLAUDE.md.

## Verification

- `just doctor` → OK
- `just test` → 2/2 PASSED (api + properties)
- `just check` → fmt + clippy + test + eslint clean

## Test plan

- [ ] `just test` passes from a clean clone (no manual `pnpm build` needed)
- [ ] `bazel build //...` analyzes successfully against an empty `migrations/` directory
- [ ] `just test-integration` with `DATABASE_URL` exported actually exercises the DB (no silent skip)